### PR TITLE
Change to draw text on the ground for non-colliding blocks if their appearance doesn't obstruct the text

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.21.5
 yarn_mappings=1.21.5+build.1
 loader_version=0.16.12
 # Mod Properties
-mod_version=3
+mod_version=4
 maven_group=com.dark_lion_jp.light_level_2025
 archives_base_name=light-level-2025-1.21.5
 # Dependencies

--- a/src/main/java/com/dark_lion_jp/light_level_2025/LLWorldRenderer.java
+++ b/src/main/java/com/dark_lion_jp/light_level_2025/LLWorldRenderer.java
@@ -1,5 +1,6 @@
 package com.dark_lion_jp.light_level_2025;
 
+import java.lang.Math;
 import java.util.Arrays;
 import java.util.List;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
@@ -28,19 +29,19 @@ import org.joml.Quaternionf;
 public class LLWorldRenderer {
 
   // Configuration constants for text rendering
-  private static final int TEXT_COLOR_DANGER = 0xFF4040;   // Red: Mobs can always spawn
-  private static final int TEXT_COLOR_NEUTRAL = 0xFFFFFF; // White: Unknown or unsupported dimension
-  private static final int TEXT_COLOR_SAFE = 0x40FF40;     // Green: Mobs cannot spawn
-  private static final int TEXT_COLOR_WARNING = 0xFFFF40; // Yellow: Mobs can spawn at night in the OverWorld
+  private static final int TEXT_COLOR_DANGER = 0xFF4040;   // Red: Indicates that mobs can always spawn.
+  private static final int TEXT_COLOR_NEUTRAL = 0xFFFFFF; // White: Used for unknown or unsupported dimensions.
+  private static final int TEXT_COLOR_SAFE = 0x40FF40;     // Green: Indicates that mobs cannot spawn.
+  private static final int TEXT_COLOR_WARNING = 0xFFFF40; // Yellow: Indicates that mobs can spawn at night in the OverWorld.
 
-  private static final float TEXT_OFFSET_Y = 0.1f;        // Vertical offset for the text position
-  private static final float TEXT_SCALE_DEBUG =
-      1 / 48f;   // Text scale when debug screen is enabled
-  private static final float TEXT_SCALE_NORMAL = 1 / 32f;  // Normal text scale
+  private static final float TEXT_OFFSET_Y_BASE = 0.1f;    // Base vertical offset for the text position.
+  private static final float TEXT_SCALE_FOR_DEBUG =
+      1 / 48f;   // Text scale used when the debug screen is enabled.
+  private static final float TEXT_SCALE_NORMAL = 1 / 32f;  // Normal text scale.
 
   // Configuration constants for rendering range
-  private static final int RENDERING_RANGE = 16;          // Horizontal rendering range around the player
-  private static final int RENDERING_VERTICAL_RANGE = 8;  // Vertical rendering range around the player
+  private static final int RENDER_RANGE_HORIZONTAL = 16;    // Horizontal rendering range around the player.
+  private static final int RENDER_RANGE_VERTICAL = 8;      // Vertical rendering range around the player.
 
   // List of blocks that should not have light levels rendered above them
   private static final List<Block> BLOCKS_TO_EXCLUDE_RENDERING = Arrays.asList(
@@ -57,67 +58,6 @@ public class LLWorldRenderer {
       Blocks.SLIME_BLOCK,
       Blocks.SOUL_SAND
   );
-
-  /**
-   * Checks if the light level information should be rendered at the given position. This check
-   * determines if a hostile mob could potentially spawn at this location based on the block's
-   * properties.
-   *
-   * @param world           The current game world.
-   * @param positionToCheck The position to check.
-   * @return True if the light level should be rendered, false otherwise.
-   */
-  private static boolean shouldRenderLightLevel(World world, BlockPos positionToCheck) {
-    // Check if the world is null. If so, no rendering should occur.
-    if (world == null) {
-      return false;
-    }
-
-    BlockState blockStateAtPositionToCheck = world.getBlockState(positionToCheck);
-
-    BlockPos positionBelow = positionToCheck.down();
-    BlockState blockStateBelow = world.getBlockState(positionBelow);
-    Block blockBelow = blockStateBelow.getBlock();
-
-    // Prevent rendering above explicitly excluded blocks.
-    if (BLOCKS_TO_EXCLUDE_RENDERING.contains(blockBelow)) {
-      return false;
-    }
-
-    // Check if the block below is opaque. Mobs cannot spawn on transparent blocks.
-    if (!blockStateBelow.isOpaque()) {
-      return false;
-    }
-
-    // Prevent rendering on blocks where mobs cannot stand to spawn due to a collision shape.
-    if (!blockStateAtPositionToCheck.getCollisionShape(world, positionToCheck).isEmpty()) {
-      return false;
-    }
-
-    // Check if the block below is in the exception list of blocks that allow mob spawning.
-    if (BLOCKS_BELOW_ALLOWING_SPAWN_EXCEPTION.contains(blockBelow)) {
-      return true;
-    }
-
-    // If the above conditions are not met, perform a more detailed check of the collision shape
-    // of the top face of the block below.
-    VoxelShape collisionShapeBelow = blockStateBelow.getCollisionShape(world,
-        positionBelow);
-    if (!collisionShapeBelow.getFace(Direction.UP).isEmpty()) {
-      Box upFaceBoundingBox = collisionShapeBelow.getFace(Direction.UP).getBoundingBox();
-      // Check if the top face covers the entire XZ area (from 0.0 to 1.0)
-      boolean coversFullXZ = MathHelper.approximatelyEquals(upFaceBoundingBox.minX, 0.0D) &&
-          MathHelper.approximatelyEquals(upFaceBoundingBox.maxX, 1.0D) &&
-          MathHelper.approximatelyEquals(upFaceBoundingBox.minZ, 0.0D) &&
-          MathHelper.approximatelyEquals(upFaceBoundingBox.maxZ, 1.0D);
-      // Check if the top face has a significant Y extent (meaning it's not just a thin sliver)
-      boolean hasSignificantY = upFaceBoundingBox.maxY > upFaceBoundingBox.minY;
-
-      return coversFullXZ && hasSignificantY;
-    }
-
-    return false;
-  }
 
   /**
    * Draws the light level text at the specified position.
@@ -149,21 +89,27 @@ public class LLWorldRenderer {
   ) {
     matrices.push();
 
-    float additionalYOffset = 0.0f;
+    // Get the visual shape of the block at the drawing position.
+    BlockState blockState = world.getBlockState(positionToDrawAt);
+    VoxelShape visualShape = blockState.getOutlineShape(world, positionToDrawAt);
 
-    // Get the visual shape of the block at the drawing position to determine its height.
-    BlockState blockStateToDrawAt = world.getBlockState(positionToDrawAt);
-    VoxelShape visualShape = blockStateToDrawAt.getOutlineShape(world, positionToDrawAt);
-    // If the visual shape is not empty, get its bounding box and use the Y length as an additional offset.
-    if (!visualShape.isEmpty()) {
-      Box boundingBox = visualShape.getBoundingBox();
-      additionalYOffset = (float) boundingBox.getLengthY();
+    // Determine the text to render.
+    String textToRender;
+    if (shouldShowBothValues) {
+      textToRender = "■" + blockLightLevel + " ☀" + skyLightLevel;
+    } else {
+      textToRender = String.valueOf(blockLightLevel);
     }
+    float textWidthScaled = textRenderer.getWidth(textToRender) * textScale;
+    float textHeightScaled = textRenderer.fontHeight * textScale;
 
-    // Translate to the drawing position above the block, incorporating the calculated Y offset.
+    // Calculate the base Y offset for the text, considering potential overlap with the block.
+    float textOffsetY = getTextOffsetY(visualShape, textWidthScaled, textHeightScaled);
+
+    // Translate to the drawing position.
     matrices.translate(
         positionToDrawAt.getX() + 0.5,
-        positionToDrawAt.getY() + TEXT_OFFSET_Y + additionalYOffset,
+        positionToDrawAt.getY() + textOffsetY,
         positionToDrawAt.getZ() + 0.5
     );
 
@@ -172,14 +118,6 @@ public class LLWorldRenderer {
 
     // Scale the text.
     matrices.scale(textScale, -textScale, textScale);
-
-    // Determine the text to render based on whether to show both block-light and sky-light levels.
-    String textToRender;
-    if (shouldShowBothValues) {
-      textToRender = "■" + blockLightLevel + " ☀" + skyLightLevel;
-    } else {
-      textToRender = String.valueOf(blockLightLevel);
-    }
 
     float textWidth = textRenderer.getWidth(textToRender);
     Matrix4f positionMatrix = matrices.peek().getPositionMatrix();
@@ -211,7 +149,6 @@ public class LLWorldRenderer {
    * @return The color code for the text.
    */
   private static int getTextColor(World world, int blockLightLevel, int skyLightLevel) {
-    // If the world is null, return a neutral color.
     if (world == null) {
       return TEXT_COLOR_NEUTRAL;
     }
@@ -219,7 +156,6 @@ public class LLWorldRenderer {
     net.minecraft.util.Identifier currentDimension = world.getRegistryKey().getValue();
 
     int textColor;
-    // Determine the text color based on the dimension and light levels.
     if (currentDimension.equals(World.OVERWORLD.getValue())) {
       if (blockLightLevel > 0) {
         textColor = TEXT_COLOR_SAFE;
@@ -247,25 +183,55 @@ public class LLWorldRenderer {
   }
 
   /**
+   * Calculates the necessary Y offset for the text to avoid overlapping with the block.
+   *
+   * @param visualShape      The visual shape of the block.
+   * @param textWidthScaled  The scaled width of the text.
+   * @param textHeightScaled The scaled height of the text.
+   * @return The Y offset to apply to the text position.
+   */
+  private static float getTextOffsetY(VoxelShape visualShape, float textWidthScaled,
+      float textHeightScaled) {
+    float textOffsetY = TEXT_OFFSET_Y_BASE;
+
+    // If the block has a visual shape, check for potential XZ-axis overlap at any rotation.
+    if (!visualShape.isEmpty()) {
+      Box blockBoundingBox = visualShape.getBoundingBox();
+      float textMaxLength = (float) Math.sqrt(
+          Math.pow(textWidthScaled, 2) + Math.pow(textHeightScaled, 2));
+      boolean textOverlapped = blockBoundingBox.intersects(
+          0.5f - textMaxLength,
+          0,
+          0.5f - textMaxLength,
+          0.5f + textMaxLength,
+          textHeightScaled,
+          0.5f + textMaxLength
+      );
+
+      if (textOverlapped) {
+        textOffsetY += (float) blockBoundingBox.getLengthY(); // Add block height if overlap occurs.
+      }
+    }
+    return textOffsetY;
+  }
+
+  /**
    * Renders the light levels around the player.
    *
    * @param worldRenderContext The world render context provided by Fabric.
    */
   public static void render(WorldRenderContext worldRenderContext) {
-    // Check if the light level rendering is enabled in the configuration.
     if (!LightLevel2025.isEnabled()) {
       return;
     }
 
     MinecraftClient client = MinecraftClient.getInstance();
-    // Ensure the client, player, world, and text renderer are not null.
     if (client == null || client.player == null || client.world == null
         || client.textRenderer == null) {
       return;
     }
 
     MatrixStack matrices = worldRenderContext.matrixStack();
-    // Ensure the matrix stack is not null.
     if (matrices == null) {
       return;
     }
@@ -280,49 +246,39 @@ public class LLWorldRenderer {
     Quaternionf cameraRotation = new Quaternionf(camera.getRotation());
 
     boolean shouldShowBothValues = client.getDebugHud().shouldShowDebugHud();
-    float textScale;
-    if (shouldShowBothValues) {
-      textScale = TEXT_SCALE_DEBUG;
-    } else {
-      textScale = TEXT_SCALE_NORMAL;
-    }
+    float textScale = shouldShowBothValues ? TEXT_SCALE_FOR_DEBUG : TEXT_SCALE_NORMAL;
 
     matrices.push();
     matrices.translate(-cameraPosition.x, -cameraPosition.y, -cameraPosition.z);
 
     BlockPos playerPosition = player.getBlockPos();
     BlockPos.Mutable positionToRenderAt = playerPosition.mutableCopy();
-    int renderingRange = RENDERING_RANGE;
-    int renderingVerticalRange = RENDERING_VERTICAL_RANGE;
+    int renderRangeHorizontal = RENDER_RANGE_HORIZONTAL;
+    int renderRangeVertical = RENDER_RANGE_VERTICAL;
 
-    // Iterate through the blocks within the rendering range around the player.
-    for (int xOffset = -renderingRange; xOffset <= renderingRange; xOffset++) {
-      for (int zOffset = -renderingRange; zOffset <= renderingRange; zOffset++) {
-        for (int yOffset = -renderingVerticalRange; yOffset <= renderingVerticalRange; yOffset++) {
+    for (int offsetX = -renderRangeHorizontal; offsetX <= renderRangeHorizontal; offsetX++) {
+      for (int offsetZ = -renderRangeHorizontal; offsetZ <= renderRangeHorizontal;
+          offsetZ++) {
+        for (int offsetY = -renderRangeVertical; offsetY <= renderRangeVertical; offsetY++) {
           positionToRenderAt.set(
-              playerPosition.getX() + xOffset,
-              playerPosition.getY() + yOffset,
-              playerPosition.getZ() + zOffset
+              playerPosition.getX() + offsetX,
+              playerPosition.getY() + offsetY,
+              playerPosition.getZ() + offsetZ
           );
 
-          // Skip blocks that are too far from the player to optimize performance.
           if (positionToRenderAt.getSquaredDistance(playerPosition)
-              > renderingRange * renderingRange * 1.5) {
+              > renderRangeHorizontal * renderRangeHorizontal * 1.5) {
             continue;
           }
 
-          // Check if the light level information should be rendered at this position.
           if (!shouldRenderLightLevel(world, positionToRenderAt)) {
             continue;
           }
 
-          // Get the block-light and sky-light levels at the current position.
           int blockLightLevel = world.getLightLevel(LightType.BLOCK, positionToRenderAt);
           int skyLightLevel = world.getLightLevel(LightType.SKY, positionToRenderAt);
-          // Determine the color of the text based on the light levels and dimension.
           int textColor = getTextColor(world, blockLightLevel, skyLightLevel);
 
-          // Draw the light level text at the current position.
           drawLightLevelText(
               world,
               matrices,
@@ -341,5 +297,57 @@ public class LLWorldRenderer {
     }
 
     matrices.pop();
+  }
+
+  /**
+   * Checks if the light level information should be rendered at the given position. This check
+   * determines if a hostile mob could potentially spawn at this location based on the block's
+   * properties.
+   *
+   * @param world           The current game world.
+   * @param positionToCheck The position to check.
+   * @return True if the light level should be rendered, false otherwise.
+   */
+  private static boolean shouldRenderLightLevel(World world, BlockPos positionToCheck) {
+    if (world == null) {
+      return false;
+    }
+
+    BlockState blockStateAtPositionToCheck = world.getBlockState(positionToCheck);
+
+    BlockPos positionBelow = positionToCheck.down();
+    BlockState blockStateBelow = world.getBlockState(positionBelow);
+    Block blockBelow = blockStateBelow.getBlock();
+
+    if (BLOCKS_TO_EXCLUDE_RENDERING.contains(blockBelow)) {
+      return false;
+    }
+
+    if (!blockStateBelow.isOpaque()) {
+      return false;
+    }
+
+    if (!blockStateAtPositionToCheck.getCollisionShape(world, positionToCheck).isEmpty()) {
+      return false;
+    }
+
+    if (BLOCKS_BELOW_ALLOWING_SPAWN_EXCEPTION.contains(blockBelow)) {
+      return true;
+    }
+
+    VoxelShape collisionShapeBelow = blockStateBelow.getCollisionShape(world,
+        positionBelow);
+    if (!collisionShapeBelow.getFace(Direction.UP).isEmpty()) {
+      Box upFaceBoundingBox = collisionShapeBelow.getFace(Direction.UP).getBoundingBox();
+      boolean coversFullXZ = MathHelper.approximatelyEquals(upFaceBoundingBox.minX, 0.0D) &&
+          MathHelper.approximatelyEquals(upFaceBoundingBox.maxX, 1.0D) &&
+          MathHelper.approximatelyEquals(upFaceBoundingBox.minZ, 0.0D) &&
+          MathHelper.approximatelyEquals(upFaceBoundingBox.maxZ, 1.0D);
+      boolean hasSignificantY = upFaceBoundingBox.maxY > upFaceBoundingBox.minY;
+
+      return coversFullXZ && hasSignificantY;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
- Text will be drawn on the ground when a non-colliding block's visuals do not interfere with the text