### PR TITLE
Upgrade to 1.21.7-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div style="display: inline">
-  <img src="https://img.shields.io/badge/Minecraft-1.21.6-white">
+  <img src="https://img.shields.io/badge/Minecraft-1.21.7--rc1-white">
   <img src="https://img.shields.io/badge/Fabric_Loader-0.16.14-white">
-  <img src="https://img.shields.io/badge/Fabric_API-0.127.1%2B1.21.6-white">
+  <img src="https://img.shields.io/badge/Fabric_API-0.128.0%2B1.21.7-white">
   <img src="https://img.shields.io/github/actions/workflow/status/dark-lion-jp/light-level-2025/build.yml?branch=main">
 </div>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,13 @@ config_version=3
 config_path=light-level-2025.yaml
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.7-rc1
+yarn_mappings=1.21.7-rc1+build.1
 loader_version=0.16.14
 # Mod Properties
-mod_version=2
+mod_version=1
 maven_group=com.dark_lion_jp.light_level_2025
-archives_base_name=light-level-2025-1.21.6
+archives_base_name=light-level-2025-1.21.7-rc1
 # Dependencies
-fabric_version=0.127.1+1.21.6
+fabric_version=0.128.0+1.21.7
 yaml_beans_version=1.17


### PR DESCRIPTION
## Dependencies
- [Fabric Loader 0.16.14](https://fabricmc.net/use/installer/)
- [Fabric API 0.128.0+1.21.7](https://modrinth.com/mod/fabric-api/version/0.128.0+1.21.7)

## Features
- Upgrade to 1.21.7-rc1
- Add option to hide safe light level values